### PR TITLE
Upgrade to image-resizer 1.0 and add default image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-# Must always be set. Defaults to 3001
+# Defaults to 3001
 PORT=3003
+
+# This should be relative to whatever your main image source path
+IMAGE_404=relative/path/image.jpg
 
 # Comment out or delete the block you're not using.
 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ Use `gulp watch` to start your local server.
 [jimmynicol]: https://github.com/jimmynicol
 [image-resizer]: https://github.com/jimmynicol/image-resizer
 [sharp]: https://github.com/lovell/sharp
+
+
+## Default Image
+
+The `.env` has a `IMAGE_404` variable that should be set as a path to an image relative to your base URL.
+
+When using S3 the path is relative to the bucket root.
+
+When using Local the path is relative to `LOCAL_FILE_PATH`.
+
+**Always** make sure the `IMAGE_404` is set as the plugin code isn't very fault tolerant to that not existing yet.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,6 +66,6 @@ gulp.task('watch', ['lint'], function () {
     script: 'index.js',
     ext: 'js',
     env: env(),
-    ignore: ['node_modules/']
+    ignore: ['node_modules/**/*.js']
   }).on('restart', ['lint']);
 });

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ app.get('/favicon.ico', function (request, response) {
   response.sendStatus(404);
 });
 
-app.get('/robots.txt', function(request, response){
+app.get('/robots.txt', function (request, response) {
   response.sendStatus(404);
 });
 
@@ -84,9 +84,9 @@ app.get('/*?', function(request, response){
 
   image.getFile()
     .pipe(new streams.identify())
-    .pipe(new streams.resizeSharp())
+    .pipe(new streams.resize())
     .pipe(new streams.filter())
-    .pipe(new streams.optimizeSharp())
+    .pipe(new streams.optimize())
     .pipe(streams.response(request, response));
 });
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node": "0.12.x"
   },
   "dependencies": {
+    "aws-sdk": "~2.0.0-rc9",
     "chalk": "~1.0.0",
     "express": "^4.9.7",
     "image-resizer": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,17 +9,15 @@
   "private": true,
   "description": "Heroku deployable image resizing service.",
   "engines": {
-    "node": ">=0.10.35"
+    "node": "0.12.x"
   },
   "dependencies": {
-    "chalk": "~0.5.1",
+    "chalk": "~1.0.0",
     "express": "^4.9.7",
-    "gm": "~1.14.2",
-    "image-resizer": "git://github.com/jimmynicol/image-resizer.git#sharp",
+    "image-resizer": "~1.0.0",
     "lodash": "~2.4.1",
     "newrelic": "^1.17.0",
-    "rollbar": "^0.4.4",
-    "sharp": "^0.8.3"
+    "rollbar": "^0.4.4"
   },
   "devDependencies": {
     "chai": "~1.9.0",

--- a/plugins/sources/local.js
+++ b/plugins/sources/local.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var env, fs, stream, util;
+
+env    = require('../../node_modules/image-resizer/src/config/environment_vars');
+fs     = require('fs');
+stream = require('stream');
+util   = require('util');
+
+
+function Local(image){
+  /* jshint validthis:true */
+  if (!(this instanceof Local)){
+    return new Local(image);
+  }
+  stream.Readable.call(this, { objectMode : true });
+  this.image = image;
+  this.path = image.path.replace(/^elocal/i,'');
+  this.filePath = env.LOCAL_FILE_PATH + '/' + this.path;
+  this.ended = false;
+}
+
+util.inherits(Local, stream.Readable);
+
+
+Local.prototype._read = function(){
+  var _this = this;
+
+  if ( this.ended ){ return; }
+
+  // pass through if there is an error on the image object
+  if (this.image.isError()){
+    this.ended = true;
+    this.push(this.image);
+    return this.push(null);
+  }
+
+  this.image.log.time('local filesystem');
+
+  fs.readFile(_this.filePath, function(err, data){
+    _this.image.log.timeEnd('local filesystem');
+
+    // if there is an error store it on the image object and pass it along
+    if (err) {
+      // FIXME Add some kind of load-attempts counter to prevent infinite loop
+      _this.filePath = env.LOCAL_FILE_PATH + '/' + env.IMAGE_404;
+      _this._read();
+      return;
+    }
+
+    // if not store the image buffer
+    else {
+      _this.image.contents = data;
+      _this.image.originalContentLength = data.length;
+    }
+
+    _this.ended = true;
+    _this.push(_this.image);
+    _this.push(null);
+  });
+};
+
+
+module.exports = Local;

--- a/plugins/sources/s3.js
+++ b/plugins/sources/s3.js
@@ -1,0 +1,79 @@
+'use strict';
+
+var env, s3, stream, util, client, bucket;
+
+env    = require('../../node_modules/image-resizer/src/config/environment_vars');
+s3     = require('aws-sdk').S3;
+stream = require('stream');
+util   = require('util');
+
+try {
+  // create an AWS S3 client with the config data
+  client = new s3({
+    accessKeyId: env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+    region: env.AWS_REGION
+  });
+  bucket = env.S3_BUCKET;
+} catch(e) {
+
+}
+
+
+function s3Stream(image){
+  /* jshint validthis:true */
+  if (!(this instanceof s3Stream)){
+    return new s3Stream(image);
+  }
+  stream.Readable.call(this, { objectMode : true });
+  this.image = image;
+  this.ended = false;
+}
+
+util.inherits(s3Stream, stream.Readable);
+
+s3Stream.prototype._read = function(){
+  var _this = this;
+
+  if ( this.ended ){ return; }
+
+  // pass through if there is an error on the image object
+  if (this.image.isError()){
+    this.ended = true;
+    this.push(this.image);
+    return this.push(null);
+  }
+
+  // Set the AWS options
+  var awsOptions = {
+    Bucket: bucket,
+    Key: this.image.path.replace(/^\//,'')
+  };
+
+  this.image.log.time('s3');
+
+  client.getObject(awsOptions, function(err, data){
+    _this.image.log.timeEnd('s3');
+
+    // if there is an error rewrite the path and _read again
+    if (err) {
+      // FIXME Add some kind of load-attempts counter to prevent infinite loop
+      _this.image.path = process.env.IMAGE_404;
+      _this._read();
+      return;
+    }
+
+    // if not store the image buffer
+    else {
+      _this.image.contents = data.Body;
+      _this.image.originalContentLength = data.Body.length;
+    }
+
+    _this.ended = true;
+    _this.push(_this.image);
+    _this.push(null);
+  });
+};
+
+
+module.exports = s3Stream;


### PR DESCRIPTION
This updates image-resizer to `v1.0` and adds support for serving up a default image. Fixes Goldbely/tracker#2013

The [default image on Pantograph staging](https://pantograph-staging.herokuapp.com/pantograph-default.jpg) is a cat.

If you request an image that exists the image is served as normal: https://pantograph-staging.herokuapp.com/uploads/product/main_image/14814/goodes-sausage-sampler.749b0e0e2fd7aadd036f2cb87dc48142.jpg

Non-existant image images will serve a cat in the requested size: https://pantograph-staging.herokuapp.com/cfill-h100-w300/some/fake/image.jpg
## Testing locally

To test locally make sure you add a default image in your local code base and set `IMAGE_404` in your `.env` file (in Pantograph) to the location of that image relative to `LOCAL_FILE_PATH`.

> E.g. Your default image is located in `/User/jgillman/goldbely/public/defaults/cat.jpg`
> `LOCAL_FILE_PATH` is `/User/jgillman/goldbely/public`
> `IMAGE_404` would be `defaults/cat.jpg`.
## Testing remotely

Staging is set up to point at the staging Pantograph instance which should have the latest code. Missing images should be filled in: https://drydock.goldbely.com/
