### PR TITLE
Force Last-Modified header for FB

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ Return an image modified to the requested parameters
 app.get('/*?', function(request, response){
   var image = new Img(request);
 
+  response.header( 'Last-Modified', new Date('2015-10-01').toUTCString() );
   response.header('X-Powered-By', 'Food from Goldbely');
 
   image.getFile()


### PR DESCRIPTION
`Last-Modified` header will supposedly fix Goldbely/tracker#2769 according to [Eatsmarter Entwicklung's comment](https://developers.facebook.com/bugs/388405488023104/?comment_id=1499157537049360) on the bug on Facebook.

**Yes,** this hardcodes the Last-Modified date. It shouldn't matter for cache reasons because once an image has been generated it should never change unless the URL changes.
