### PR TITLE
Upgrade image-resizer to 1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "aws-sdk": "~2.0.0-rc9",
-    "image-resizer": "~1.2.0",
+    "image-resizer": "~1.3.0",
     "express": "^4.9.7",
     "lodash": "~2.4.1",
     "chalk": "~1.0.0",


### PR DESCRIPTION
# Changes in IR 1.3
- Bumped sharp version
- Changes Last Modified date to something more than UnixTime 0 (works around the FB bug!!!)
- Fixed issues with removing mods from path

---

Most importantly, it works around Facebook's image grabbing bug:

See for yourself here: https://developers.facebook.com/tools/debug/og/object?q=https%3A%2F%2Fgil.mn%2Fimage-test.html

![screen shot 2015-10-12 at 9 33 58 am](https://cloud.githubusercontent.com/assets/172217/10433217/f383bda4-70c4-11e5-87c1-b79a6d4be179.png)
