### PR TITLE
Update error tracking libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   },
   "dependencies": {
     "aws-sdk": "~2.0.0-rc9",
-    "image-resizer": "~1.3.0",
-    "express": "^4.9.7",
-    "lodash": "~2.4.1",
     "chalk": "~1.0.0",
-    "sharp": "^0.10.1",
-    "newrelic": "^1.17.0",
-    "rollbar": "^0.4.4"
+    "express": "^4.9.7",
+    "image-resizer": "~1.3.0",
+    "lodash": "~2.4.1",
+    "newrelic": "^1.24.0",
+    "rollbar": "^0.4.5",
+    "sharp": "^0.10.1"
   },
   "devDependencies": {
     "chai": "~1.9.0",


### PR DESCRIPTION
Just to ensure we're not loosing data b/c they're out of date
